### PR TITLE
feat(fs-tpp-snap): added a new entry to define the tpp-snap version

### DIFF
--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -19,6 +19,7 @@ export interface FSXAModuleOptions {
   defaultLocale: string;
   devMode?: boolean;
   customRoutes?: string;
+  fsTppVersion: string;
 }
 const FSXAModule: Module<FSXAModuleOptions> = function (moduleOptions) {
   // try to access config file
@@ -78,6 +79,7 @@ const FSXAModule: Module<FSXAModuleOptions> = function (moduleOptions) {
     options: {
       components: options.components || {},
       defaultLocale: options.defaultLocale,
+      fsTppVersion: options.fsTppVersion,
     },
   });
 

--- a/templates/IndexPage.vue
+++ b/templates/IndexPage.vue
@@ -5,6 +5,7 @@
     defaultLocale="<%= options.defaultLocale %>"
     :components="components"
     :handleRouteChange="handleRouteChange"
+    fsTppVersion="<%= options.fsTppVersion %>"
   />
 </template>
 


### PR DESCRIPTION
We have added the possibility to define the tpp-snap version in the fsxa.config.ts file. If no version is defined the default is used.