### PR TITLE
feat: enable usage of navigationFilter and preFilterFetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fsxa-nuxt-module",
-  "version": "3.5.1",
+  "version": "3.5.2-alpha.45",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1294,7 +1294,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -1632,7 +1631,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -1640,8 +1638,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "colorette": {
       "version": "1.2.2",
@@ -1841,6 +1838,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -1959,9 +1965,9 @@
       "dev": true
     },
     "date-fns": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -2691,17 +2697,29 @@
       "dev": true
     },
     "fsxa-api": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-5.3.1.tgz",
-      "integrity": "sha512-vEggTHeR+wpvMx8ZYAeEFjefHMzTuhZBxXC1KV+01/WZUCwRReT5L5lpD65Oz9vyaQkUlO2xUqOuuQPoQEFnMA==",
+      "version": "6.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-6.0.0-alpha.1.tgz",
+      "integrity": "sha512-f+dWzajIkRGNzFizKPXwWYaQrd4uAY7q3pbQ3eStUX0fb3y38VDtLFVB4sJE8YYxNmNX+fjlrHa24n3nUHlOTQ==",
       "requires": {
         "body-parser": "^1.19.0",
+        "chalk": "^4.1.2",
+        "cors": "^2.8.5",
         "date-fns": "^2.23.0",
         "lodash": "^4.17.21",
         "qs": "^6.10.1",
-        "saxes": "^5.0.1"
+        "saxes": "^5.0.1",
+        "tslib": "^2.3.1"
       },
       "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "qs": {
           "version": "6.10.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
@@ -2709,16 +2727,22 @@
           "requires": {
             "side-channel": "^1.0.4"
           }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
     "fsxa-pattern-library": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fsxa-pattern-library/-/fsxa-pattern-library-3.2.4.tgz",
-      "integrity": "sha512-osF9TUZINuVlhjZtQE//bCxwR+GCTARiV2Ra5uq97ujrQzu2FY/TdqPzwu/T98S4Cf4Ii0He3h+XmaJpht1dRw==",
+      "version": "4.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/fsxa-pattern-library/-/fsxa-pattern-library-4.0.0-alpha.4.tgz",
+      "integrity": "sha512-sznrurSF8JP/x0nn5r8MWcY+1eQ0ZLVwSHrL3rJELaCZ9nhfoDeV8JwBNYGXrY0Muf9qHZH75Tb9TnxAgINtSw==",
       "requires": {
-        "fsxa-api": "^5.3.1",
+        "fsxa-api": "^6.0.0-alpha.1",
         "prismjs": "^1.24.1",
+        "setimmediate": "^1.0.5",
         "vue": "^2.6.14",
         "vue-prism-component": "^1.2.0",
         "vue-property-decorator": "8.2.2",
@@ -2944,8 +2968,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -6130,6 +6153,11 @@
         "path-key": "^3.0.0"
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
@@ -6549,9 +6577,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -7176,6 +7204,11 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -7519,7 +7552,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
   "dependencies": {
     "cross-fetch": "^3.1.4",
     "express": "^4.17.1",
-    "fsxa-api": "^5.3.1",
-    "fsxa-pattern-library": "^3.2.4",
+    "fsxa-api": "^6.0.0-alpha.1",
+    "fsxa-pattern-library": "^4.0.0-alpha.4",
     "lodash.camelcase": "^4.3.0",
     "lodash.merge": "^4.6.2",
     "lodash.startcase": "^4.4.0"

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,11 +1,11 @@
 import express, { Request, Response, NextFunction } from "express";
-import { FSXAApi, FSXAApiErrors, NavigationData } from "fsxa-api";
+import { FSXAApiErrors, FSXARemoteApi, NavigationData } from "fsxa-api";
 import getExpressRouter from "fsxa-api/dist/lib/integrations/express";
 import { ServerMiddleware } from "@nuxt/types";
 require("cross-fetch/polyfill");
 
 export interface MiddlewareContext {
-  fsxaAPI: FSXAApi;
+  fsxaAPI: FSXARemoteApi;
 }
 export type CustomRouteHandler = (
   context: MiddlewareContext,
@@ -19,16 +19,15 @@ export interface CustomRoute {
   handler: CustomRouteHandler;
 }
 const generateSitemap = async (
-  fsxaAPI: FSXAApi,
+  fsxaAPI: FSXARemoteApi,
   req: Request,
   res: Response,
 ) => {
   const host = [req.protocol, "://", req.headers.host].join("");
   try {
-    const response: NavigationData | null = await fsxaAPI.fetchNavigation(
-      null,
-      req.params.language,
-    );
+    const response: NavigationData | null = await fsxaAPI.fetchNavigation({
+      locale: req.params.language,
+    });
     const locations = Object.keys(response.seoRouteMap);
     res.set("Content-Type", "text/xml");
     res.send(`<?xml version="1.0" encoding="UTF-8"?>
@@ -60,7 +59,7 @@ export interface MiddlewareOptions {
 }
 const createMiddleware = (
   options: MiddlewareOptions,
-  api: FSXAApi,
+  api: FSXARemoteApi,
 ): ServerMiddleware => {
   const middleware: ServerMiddleware = (req, res, next) => {
     const app = express();

--- a/templates/IndexPage.vue
+++ b/templates/IndexPage.vue
@@ -89,7 +89,7 @@ export default {
   methods: {
     handleRouteChange(route) {
       this.$router.push({ path: route });
-    },
+    }
   },
 };
 </script>

--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -1,16 +1,11 @@
 import { getFSXAModule } from "fsxa-pattern-library";
 
 export default function (ctx, inject) {
-  const fsxaModule = getFSXAModule(process.env.FSXA_MODE, {
-    mode: "proxy",
-    baseUrl: {
-      client: "/api/fsxa",
-      server: `http://${process.env.NUXT_HOST || "localhost"}:${
-        process.env.NUXT_PORT || 3000
-      }/api/fsxa`,
-    },
-    logLevel: "<%= options.logLevel %>",
-  });
+  const proxyApiConfig = {url: `http://${process.env.NUXT_HOST || "localhost"}:${
+    process.env.NUXT_PORT || 3000
+  }/api/fsxa`, logLevel: "<%= options.logLevel %>"}
+
+  const fsxaModule = getFSXAModule({mode: 'proxy', config: proxyApiConfig}); 
   if (typeof ctx.store === "undefined") {
     throw new Error(
       "[FSXA-Module] Could not find Vuex-Store. Please initialize it.",


### PR DESCRIPTION
The new FSXAApi classes were used, to enable the usage of the navigationFilter and preFilterFetch in
the fsxa.config.(ts/js) file.

BREAKING CHANGE: The new FSXAApi classes were used and these have slightly different method
signatures. Please read the coming migration guide in the fsxa-pwa project.