### PR TITLE
Possibility to customize the middleware path by an environment variable

### DIFF
--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -143,8 +143,11 @@ const FSXAModule: Module<FSXAModuleOptions> = function (moduleOptions) {
     options.logLevel,
   );
   // create serverMiddleware
+  const path: string = process.env.FSXA_NUXT_PUBLIC_PATH
+    ? `${process.env.FSXA_NUXT_PUBLIC_PATH}/api`
+    : "/api";
   this.addServerMiddleware({
-    path: "/api",
+    path,
     handler: createMiddleware(
       {
         customRoutes,

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -143,8 +143,8 @@ const FSXAModule: Module<FSXAModuleOptions> = function (moduleOptions) {
     options.logLevel,
   );
   // create serverMiddleware
-  const path: string = process.env.FSXA_NUXT_PUBLIC_PATH
-    ? `${process.env.FSXA_NUXT_PUBLIC_PATH}/api`
+  const path = process.env.FSXA_API_BASE_URL
+    ? `${process.env.FSXA_API_BASE_URL}/api`
     : "/api";
   this.addServerMiddleware({
     path,

--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -1,13 +1,13 @@
 import { getFSXAModule } from "fsxa-pattern-library";
 
 export default function (ctx, inject) {
+  const baseURL = `http://${process.env.NUXT_HOST || "localhost"}:${process.env.NUXT_PORT || 3000}`
+  const path = process.env.FSXA_NUXT_PUBLIC_PATH ? `/${process.env.FSXA_NUXT_PUBLIC_PATH}/api/fsxa` : "/api/fsxa"
   const fsxaModule = getFSXAModule(process.env.FSXA_MODE, {
     mode: "proxy",
     baseUrl: {
-      client: "/api/fsxa",
-      server: `http://${process.env.NUXT_HOST || "localhost"}:${
-        process.env.NUXT_PORT || 3000
-      }/api/fsxa`,
+      client: path,
+      server: baseURL + path
     },
     logLevel: "<%= options.logLevel %>",
   });

--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -2,7 +2,7 @@ import { getFSXAModule } from "fsxa-pattern-library";
 
 export default function (ctx, inject) {
   const baseURL = `http://${process.env.NUXT_HOST || "localhost"}:${process.env.NUXT_PORT || 3000}`
-  const path = process.env.FSXA_NUXT_PUBLIC_PATH ? `/${process.env.FSXA_NUXT_PUBLIC_PATH}/api/fsxa` : "/api/fsxa"
+  const path = process.env.FSXA_API_BASE_URL ? `/${process.env.FSXA_API_BASE_URL}/api/fsxa` : "/api/fsxa"
   const fsxaModule = getFSXAModule(process.env.FSXA_MODE, {
     mode: "proxy",
     baseUrl: {


### PR DESCRIPTION
The changes make it possible to customize the middleware path via an environment variable. To do this, simply set the environment variable "FSXA_NUXT_PUBLIC_PATH".

A small example is when the environment variable is set to "nuxt-en-kh".

All requests will then be sent via the URL "<base_url>/nuxt-en-kh/api/fsxa/" and no longer via "<base_url>/api/fsxa/"