### PR TITLE
feat: enable usage of navigationFilter and preFilterFetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [3.8.0](https://github.com/e-Spirit/fsxa-nuxt-module/compare/v3.7.0...v3.8.0) (2021-12-15)
-
-
-### Features
-
-* enable usage of navigationFilter and preFilterFetch ([#18](https://github.com/e-Spirit/fsxa-nuxt-module/issues/18)) ([c475a6c](https://github.com/e-Spirit/fsxa-nuxt-module/commit/c475a6c2b404194016fac688d171e99e2b4186d0)), closes [#12](https://github.com/e-Spirit/fsxa-nuxt-module/issues/12) [#16](https://github.com/e-Spirit/fsxa-nuxt-module/issues/16)
-
 # [3.7.0](https://github.com/e-Spirit/fsxa-nuxt-module/compare/v3.6.0...v3.7.0) (2021-12-03)
 
 ### Features


### PR DESCRIPTION
The new FSXAApi classes were used, to enable the usage of the navigationFilter and preFilterFetch in
the fsxa.config.(ts/js) file.

BREAKING CHANGE: 

1. The original fsxa-api class was removed and the new ones FSXAProxyApi and FSXARemoteApi are used. Their have a slightly different, but better, method signatures. For more information, please read the [migration guide in the CHANGELOG of the FSXA-API](https://github.com/e-Spirit/fsxa-api/blob/master/CHANGELOG.md#migration-guide).
2. Environment variables FSXA_HOST and FSXA_PORT has be configured in your production environments. Make sure to set the variables in your PWA deployments. In testing scenarios, localhost:3000 will be used. 