### PR TITLE
feat(dependencies): update fsxa-api and fsxa-pattern-library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2657,9 +2657,9 @@
       "dev": true
     },
     "fsxa-api": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-8.4.0.tgz",
-      "integrity": "sha512-So2QzxGFZCGf2sGo0hEzGKhjgxsjhGO5Y+o7WNpVQ91KfOuUqE+wdSldiA6eIteftwpavv44c1lXPOFTb5N0wA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-9.0.0.tgz",
+      "integrity": "sha512-XOgdzI2PC+heFrJB9fkKFpQkbub3SFVFc3ZmEzLNR7VJgDBGPGxYQFRUDlzdltJLzM17YxYNp+cIdrM9/ixknA==",
       "requires": {
         "@types/ws": "^8.2.2",
         "better-sse": "^0.7.1",
@@ -2695,11 +2695,11 @@
       }
     },
     "fsxa-pattern-library": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/fsxa-pattern-library/-/fsxa-pattern-library-6.3.0.tgz",
-      "integrity": "sha512-BJOzG/nfRoq0mu8oNztYjtsOa5PpezJnUnmit6cV0Itd+ruaGNP4UgMPUqYE9tTaOMyN7VKxTM9A79qrMjBn7Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fsxa-pattern-library/-/fsxa-pattern-library-7.0.0.tgz",
+      "integrity": "sha512-7KkiLW3mkp7AYx+8nimn90aASu/865j+lMM7tXMbn3DYyDDWO+gLbgmGX6pggcNJlXEhq55lAMuY/3xz9l3P4w==",
       "requires": {
-        "fsxa-api": "^8.4.0",
+        "fsxa-api": "^9.0.0",
         "prismjs": "^1.25.0",
         "setimmediate": "^1.0.5",
         "vue": "^2.6.14",
@@ -6538,9 +6538,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "dependencies": {
     "cross-fetch": "^3.1.4",
     "express": "^4.17.1",
-    "fsxa-api": "^8.4.0",
-    "fsxa-pattern-library": "^6.3.0",
+    "fsxa-api": "^9.0.0",
+    "fsxa-pattern-library": "^7.0.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.merge": "^4.6.2",
     "lodash.startcase": "^4.4.0"


### PR DESCRIPTION
update fsxa-api and fsxa-pattern-library to latest major version

BREAKING CHANGE: The latest fsxa-api version has a new return type for fetchProjectProperties and a
new format for the ImageMap type. For details, check the breaking changes in the fsxa-api.