### PR TITLE
feat(dependencies): update fsxa-stack dependencies to their latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2650,9 +2650,9 @@
       "dev": true
     },
     "fsxa-api": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-9.0.2.tgz",
-      "integrity": "sha512-P4eACccttYnxSF9pODEFYraCVN3VdaQD7OEy+oIS4U52QiX1csyH7G0tW7mNvCGARudkjOhsohK4MdmEfVu6aw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-10.0.0.tgz",
+      "integrity": "sha512-bf0xUNXbp083b7PRZYVW7g8NdfSPwaucyV980uar0X6887PE9P0XGZxNH9IKoCFOxKPXCO5HJB91P6nKI19crA==",
       "requires": {
         "@types/ws": "^8.2.2",
         "better-sse": "^0.7.1",
@@ -2688,11 +2688,11 @@
       }
     },
     "fsxa-pattern-library": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/fsxa-pattern-library/-/fsxa-pattern-library-7.0.2.tgz",
-      "integrity": "sha512-NsP4+DJBUilsthJLgtBgyOQwgOLQR4r8EnMCAVzeOEh5CCZVhAiEFMrhOJWSkDVQP9mLExrtPS8YNDOSlvmQfA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/fsxa-pattern-library/-/fsxa-pattern-library-8.0.0.tgz",
+      "integrity": "sha512-vAQ38D6Oa6xm4fgyLvL3BjjPw4Lu4/vFgQMMXFneaDsuZfFNPVfcrPsdMmCqtdIezQ5BY9Fw/8wMrhsOWv4CAA==",
       "requires": {
-        "fsxa-api": "^9.0.2",
+        "fsxa-api": "^10.0.0",
         "prismjs": "^1.27.0",
         "setimmediate": "^1.0.5",
         "vue": "^2.6.14",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "dependencies": {
     "cross-fetch": "^3.1.5",
     "express": "^4.17.1",
-    "fsxa-api": "^9.0.2",
-    "fsxa-pattern-library": "^7.0.2",
+    "fsxa-api": "^10.0.0",
+    "fsxa-pattern-library": "^8.0.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.merge": "^4.6.2",
     "lodash.startcase": "^4.4.0"


### PR DESCRIPTION
Increased fsxa-api to 10.0.0 and fsxa-pattern.library to 8.0.0

BREAKING CHANGE: Links inside of RichtTextElements will now be mapped in the same way as the value
of CMS_INPUT_LINK. Please refer the FSXA-API CHANGELOG.md for more information.